### PR TITLE
Fixed makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,8 +9,7 @@ ROOT_DIR := $(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
 # the dev version includes development node modules
 images:
 	docker build -t jenca-cloud/$(SERVICE):latest .
-	docker rmi jenca-cloud/$(SERVICE):$(VERSION)
-	docker tag jenca-cloud/$(SERVICE):latest jenca-cloud/$(SERVICE):$(VERSION)
+	docker tag -f jenca-cloud/$(SERVICE):latest jenca-cloud/$(SERVICE):$(VERSION)
 
 test:
 	docker run -ti --rm \


### PR DESCRIPTION
If you run `docker rmi jenca-cloud/$(SERVICE):$(VERSION)` before tagging the docker image the command will fail with the following logs:

```Bash
...
Successfully built 4dd20db9c50d
docker rmi jenca-cloud/jenca-gui:1.0.0
Error response from daemon: could not find image: no such id: jenca-cloud/jenca-gui:1.0.0
Error: failed to remove images: [jenca-cloud/jenca-gui:1.0.0]
make: *** [images] Error 1
```

I think it's easier to just add the force tag to the docker tag command. Without the force the command can't be executed multiple times.